### PR TITLE
Make -default flag optional, if not provided return dns error on default requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Example:
         -allow-transfer 1.2.3.4,::1
 
 A query for `example.net` or `example.com` will go to `8.8.8.8:53`, the default.
-However, a query for `subdomain.example.com` will go to `8.8.4.4:53`.
+However, a query for `subdomain.example.com` will go to `8.8.4.4:53`. `-default`
+is optional - if it is not given then the server will return a failure for
+queries for domains where a route has not been given.
 
 # Setup #
 

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -109,9 +109,10 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 
 	if *defaultServer == "" {
 		dns.HandleFailed(w, req)
-	} else {
-		proxy(*defaultServer, w, req)
+		return
 	}
+
+	proxy(*defaultServer, w, req)
 }
 
 func isTransfer(req *dns.Msg) bool {

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -46,9 +46,7 @@ var (
 
 func main() {
 	flag.Parse()
-	if !validHostPort(*defaultServer) {
-		log.Fatal("-default is required, must be valid host:port")
-	}
+
 	transferIPs = strings.Split(*allowTransfer, ",")
 	routes = make(map[string]string)
 	if *routeList != "" {
@@ -106,7 +104,12 @@ func route(w dns.ResponseWriter, req *dns.Msg) {
 			return
 		}
 	}
-	proxy(*defaultServer, w, req)
+
+	if *defaultServer == "" {
+		dns.HandleFailed(w, req)
+	} else {
+		proxy(*defaultServer, w, req)
+	}
 }
 
 func isTransfer(req *dns.Msg) bool {

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -13,7 +13,9 @@ Example usage:
                 -allow-transfer 1.2.3.4,::1
 
 A query for example.net or example.com will go to 8.8.8.8:53, the default.
-However, a query for subdomain.example.com will go to 8.8.4.4:53.
+However, a query for subdomain.example.com will go to 8.8.4.4:53. -default
+is optional - if it is not given then the server will return a failure for
+queries for domains where a route has not been given.
 */
 package main
 


### PR DESCRIPTION
This is useful to filter out queries that should not go to any server.