### PR TITLE
Add DNS over HTTPS, and passivedns style log.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ Example:
     $ go run dns_reverse_proxy.go -address :53 \
         -default 8.8.8.8:53 \
         -route .example.com.=8.8.4.4:53 \
-	-route .example2.com.=8.8.4.4:53,1.1.1.1:53 \
-	-route .example3.com.=https://dns.alidns.com \
+        -route .example2.com.=8.8.4.4:53,1.1.1.1:53 \
+        -route .example3.com.=https://dns.alidns.com \
         -allow-transfer 1.2.3.4,::1
 
 A query for `example.net` or `example.com` will go to `8.8.8.8:53`, the default.
 However, a query for `subdomain.example.com` will go to `8.8.4.4:53`. `.example3.com` will go to `https://dns.alidns.com` use `DNS over HTTPS`. `-default`
 is optional - if it is not given then the server will return a failure for
 queries for domains where a route has not been given.
+
+It generate logs in [passivedns](https://github.com/gamelinux/passivedns) style:
+```
+1644906118.454894||10.0.1.27:52639||114.114.114.114:53||IN||gsp64-ssl.ls.apple.com.||CNAME||gsp64-ssl.ls-apple.com.akadns.net.||2431||1
+1644906118.454932||10.0.1.27:52639||114.114.114.114:53||IN||gsp64-ssl.ls-apple.com.akadns.net.||A||17.142.171.5||69||1
+1644906118.454942||10.0.1.27:52639||114.114.114.114:53||IN||gsp64-ssl.ls-apple.com.akadns.net.||A||17.142.171.6||69||1
+1644906118.454948||10.0.1.27:52639||114.114.114.114:53||IN||gsp64-ssl.ls-apple.com.akadns.net.||A||17.142.171.7||69||1
+```
 
 # Setup #
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@ Example:
     $ go run dns_reverse_proxy.go -address :53 \
         -default 8.8.8.8:53 \
         -route .example.com.=8.8.4.4:53 \
+	-route .example2.com.=8.8.4.4:53,1.1.1.1:53 \
+	-route .example3.com.=https://dns.alidns.com \
         -allow-transfer 1.2.3.4,::1
 
 A query for `example.net` or `example.com` will go to `8.8.8.8:53`, the default.
-However, a query for `subdomain.example.com` will go to `8.8.4.4:53`. `-default`
+However, a query for `subdomain.example.com` will go to `8.8.4.4:53`. `.example3.com` will go to `https://dns.alidns.com` use `DNS over HTTPS`. `-default`
 is optional - if it is not given then the server will return a failure for
 queries for domains where a route has not been given.
 

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -153,7 +153,7 @@ func main() {
 func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 	q := req.Question[0]
 	lcName := strings.ToLower(q.Name)
-	fmt.Println("lcName", lcName, q.Qtype)
+	//fmt.Println("lcName", lcName, q.Qtype)
 	domain := strings.TrimSuffix(lcName, ".")
 
 	resolver := doh.Resolver{
@@ -237,7 +237,7 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 	}
 
 	m.Answer = append(m.Answer, answers...)
-	fmt.Println(lcName, answers)
+	//fmt.Println(lcName, answers)
 	err := w.WriteMsg(m)
 	if err != nil {
 		log.Printf("Error writing msg %s\n", err)

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -196,5 +196,17 @@ func proxy(addr string, w dns.ResponseWriter, req *dns.Msg) {
 		dns.HandleFailed(w, req)
 		return
 	}
+
 	w.WriteMsg(resp)
+	logRet(addr, req, resp)
+}
+
+func logRet(addr string, req *dns.Msg, resp *dns.Msg) {
+	quest := req.Question[0]
+	fmt.Println("x--------------------------------------------------------")
+	fmt.Println(time.Now().Format(time.RFC3339), addr)
+	fmt.Println(quest.String())
+	fmt.Println(resp.String())
+	//fmt.Println("name: ", quest.Name, "type:", quest.Qtype, "str:", quest.String())
+
 }

--- a/dns_reverse_proxy.go
+++ b/dns_reverse_proxy.go
@@ -85,13 +85,13 @@ var (
 	address = flag.String("address", ":53", "Address to listen to (TCP and UDP)")
 
 	defaultServer = flag.String("default", "",
-	"Default DNS server where to send queries if no route matched (host:port)")
+		"Default DNS server where to send queries if no route matched (host:port)")
 
 	routeLists flagStringList
 	routes     map[string][]string
 
 	allowTransfer = flag.String("allow-transfer", "",
-	"List of IPs allowed to transfer (AXFR/IXFR)")
+		"List of IPs allowed to transfer (AXFR/IXFR)")
 	transferIPs []string
 )
 
@@ -157,7 +157,7 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 	domain := strings.TrimSuffix(lcName, ".")
 
 	resolver := doh.Resolver{
-		Host: addr,
+		Host:  addr,
 		Class: doh.IN,
 	}
 
@@ -167,7 +167,7 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 	m.Authoritative = true
 
 	var answers []dns.RR
-	hdr := dns.RR_Header{Name: lcName, Rrtype:q.Qtype, Class: dns.ClassINET}
+	hdr := dns.RR_Header{Name: lcName, Rrtype: q.Qtype, Class: dns.ClassINET}
 
 	switch q.Qtype {
 	case dns.TypeA:
@@ -177,7 +177,7 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 			break
 		}
 
-		for _, a := range ans{
+		for _, a := range ans {
 			r := new(dns.A)
 			r.Hdr = hdr
 			r.A = net.ParseIP(a.IP4)
@@ -190,7 +190,7 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 			break
 		}
 
-		for _, a := range ans{
+		for _, a := range ans {
 			r := new(dns.AAAA)
 			r.Hdr = hdr
 			r.AAAA = net.ParseIP(a.IP6)
@@ -203,25 +203,25 @@ func lookupDoH(addr string, w dns.ResponseWriter, req *dns.Msg) *dns.Msg {
 			break
 		}
 
-		for _, a := range ans{
+		for _, a := range ans {
 			r := new(dns.CNAME)
 			r.Hdr = hdr
 			cname := a.CNAME
-			if !strings.HasSuffix(cname, "."){
+			if !strings.HasSuffix(cname, ".") {
 				cname = cname + "."
 			}
 			r.Target = cname
 			answers = append(answers, r)
 		}
 	case dns.TypeSOA:
-		
+
 		ans, _, err := resolver.LookupSOA(domain)
 		if err != nil {
 			log.Println(err)
 			break
 		}
 
-		for _, a := range ans{
+		for _, a := range ans {
 			r := new(dns.SOA)
 			r.Hdr = hdr
 			r.Ns = a.PrimaryNS
@@ -320,7 +320,7 @@ func proxy(addr string, w dns.ResponseWriter, req *dns.Msg) {
 	if strings.HasPrefix(addr, "https://") {
 		addr = strings.Replace(addr, "https://", "", 1)
 		resp = lookupDoH(addr, w, req)
-	}else{
+	} else {
 		c := &dns.Client{Net: transport}
 		var _ time.Duration
 		var err error
@@ -334,12 +334,12 @@ func proxy(addr string, w dns.ResponseWriter, req *dns.Msg) {
 	w.WriteMsg(resp)
 
 	go func() {
-		
-		for _,r := range resp.Answer{
+
+		for _, r := range resp.Answer {
 			p := new(pdnsLog)
 
 			p.dnsClient = w.RemoteAddr().String()
-			p.timestamp = fmt.Sprintf("%f", float64(time.Now().UnixMicro()) / float64(1e6))
+			p.timestamp = fmt.Sprintf("%f", float64(time.Now().UnixMicro())/float64(1e6))
 			p.dnsServer = addr
 			p.ttl = fmt.Sprintf("%d", r.Header().Ttl)
 			p.rrClass = dns.Class(r.Header().Class).String()
@@ -348,11 +348,11 @@ func proxy(addr string, w dns.ResponseWriter, req *dns.Msg) {
 				p.query = rec.Hdr.Name
 				p.queryType = dns.Type(rec.Hdr.Rrtype).String()
 				p.answer = rec.A.String()
-			}else if rec, ok := r.(*dns.AAAA); ok {
+			} else if rec, ok := r.(*dns.AAAA); ok {
 				p.queryType = dns.Type(rec.Hdr.Rrtype).String()
 				p.query = rec.Hdr.Name
 				p.answer = rec.AAAA.String()
-			}else if rec, ok := r.(*dns.CNAME); ok {
+			} else if rec, ok := r.(*dns.CNAME); ok {
 				p.queryType = dns.Type(rec.Hdr.Rrtype).String()
 				p.query = rec.Hdr.Name
 				p.answer = rec.Target
@@ -362,5 +362,3 @@ func proxy(addr string, w dns.ResponseWriter, req *dns.Msg) {
 		}
 	}()
 }
-
-

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/StalkR/dns-reverse-proxy
 go 1.15
 
 require (
+	github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6
 	github.com/miekg/dns v1.1.41
 	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
 	golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6 h1:4NNbNM2Iq/k57qEu7WfL67UrbPq1uFWxW4qODCohi+0=
+github.com/babolivier/go-doh-client v0.0.0-20201028162107-a76cff4cb8b6/go.mod h1:J29hk+f9lJrblVIfiJOtTFk+OblBawmib4uz/VdKzlg=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=


### PR DESCRIPTION
Support DNS over HTTPS proxy,  usage: ` -route .example3.com.=https://dns.alidns.com `,  so certain domains can be lookuped using DoH protol. It can be useful when your local network has DNS poisoning.